### PR TITLE
There is not need to call run  after forExpression

### DIFF
--- a/src/main/scala/io_monad/IOTest2.scala
+++ b/src/main/scala/io_monad/IOTest2.scala
@@ -12,6 +12,6 @@ object IOTest2 extends App {
         _         <- putStrLn(s"First: $fNameUC, Last: $lNameUC")
     } yield ()
 
-    forExpression.run
+    forExpression
 
 }


### PR DESCRIPTION
The run method executes the monad returned by forExpression.
This is a IO Monad that receives Unit and returns Unit.
To show my point this is the example modified to return a IO[String]:

```
def forExpression: IO[String] = for {
    _         <- putStrLn("First name?")
    firstName <- getLine
    _         <- putStrLn(s"Last name?")
    lastName  <- getLine
    fNameUC   = firstName.toUpperCase
    lNameUC   = lastName.toUpperCase
    _         <- putStrLn(s"First: $fNameUC, Last: $lNameUC")
} yield "This last monad is executed with the .run"

val result = forExpression 
println("And lastly, the monad returned: ")
println(result.run)
```